### PR TITLE
doc: updated URLs in README

### DIFF
--- a/README
+++ b/README
@@ -52,7 +52,7 @@ options, otherwise support will be automatically detected.
 
 The following packages are required by this driver:
 
-- libdrm-armada   git://git.armlinux.org.uk/~rmk/libdrm-armada.git/
+- libdrm-armada   https://github.com/novena-next/libdrm-armada
 
 The following packages are optional, but are required for building
 etnaviv and etnadrm:
@@ -78,7 +78,7 @@ These instructions give the exact build procedure for building
 xf86-video-armada to support the etnadrm GPU driver without the etnaviv
 and vivante GPU drivers.  This is what most people will require:
 
-$ git clone git://git.armlinux.org.uk/~rmk/libdrm-armada.git/
+$ git clone https://github.com/novena-next/libdrm-armada
 $ cd libdrm-armada
 $ mkdir m4; autoreconf -f -i
 $ ./configure --prefix=/usr
@@ -87,7 +87,7 @@ $ make install
 $ cd ..
 $ git clone https://github.com/laanwj/etna_viv.git
 $ ETNA_SRC=$PWD/etna_viv
-$ git clone git://git.armlinux.org.uk/~rmk/xf86-video-armada.git/
+$ git clone https://github.com/novena-next/xf86-video-armada
 $ cd xf86-video-armada
 $ git checkout unstable-devel
 $ ./autogen.sh --prefix=/usr --disable-vivante --disable-etnaviv \


### PR DESCRIPTION
changed README to point to our copies of the repos instead of non-existant upstream repos #1

However, when I tried compiling this using the instructions in the readme, I get an error about libdrm not being found when I run `./configure`. I do have a version that is >= 2.4.38. Tested on Debian 11 (bullseye).

```
checking for clock_gettime... yes
./configure: line 12150: syntax error near unexpected token `LIBDRM,'
./configure: line 12150: `PKG_CHECK_MODULES(LIBDRM, libdrm >= 2.4.38)'
user@host:~/libdrm-armada$ apt list --installed libdrm-dev
Listing... Done
libdrm-dev/stable,now 2.4.104-1 amd64 [installed]
```

At any rate, this is not related to the original issue of the URL for the repo being the dead upstream server.